### PR TITLE
[libxmlpp] Improvement and review for Conan 2.x migration

### DIFF
--- a/recipes/libxmlpp/2.x.x/conandata.yml
+++ b/recipes/libxmlpp/2.x.x/conandata.yml
@@ -9,5 +9,11 @@ sources:
 patches:
   "5.0.1":
     - patch_file: "patches/5.0.1-0001-enable_static_builds_on_msvc.patch"
+      patch_type: "portability"
+      patch_description: "Manage dllexport correctly to be able to build static libraries on MSVC"
+      patch_source: "https://github.com/libxmlplusplus/libxmlplusplus/commit/2a2825c67a30ea34f3514659bfd91111db8e009d.patch"
   "2.42.1":
     - patch_file: "patches/2.42.1-0001-enable_static_builds_on_msvc.patch"
+      patch_type: "portability"
+      patch_description: "Manage dllexport correctly to be able to build static libraries on MSVC"
+      patch_source: "https://github.com/libxmlplusplus/libxmlplusplus/commit/2a2825c67a30ea34f3514659bfd91111db8e009d.patch"

--- a/recipes/libxmlpp/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/libxmlpp/2.x.x/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(libxml++ REQUIRED CONFIG)
 

--- a/recipes/libxmlpp/2.x.x/test_package/conanfile.py
+++ b/recipes/libxmlpp/2.x.x/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,7 +21,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = f'{os.path.join("bin", "test_package")} \
-                    {os.path.join(self.source_folder, "example.xml")}'
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            xml_path = os.path.join(self.source_folder, "example.xml")
+            self.run(f"{bin_path} {xml_path}", env="conanrun")


### PR DESCRIPTION

- Update Conandata.yml with extra information about patches
- Add test_v1_package for Conan 1.x testing
- Pkgconfig optional from system when configured
- Re-use libversion as property
- Organize components to be cross-compatible with Conan 1.x and 2.x
- Fix license folder path

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
