### PR TITLE
[etcd-cpp-apiv3] Review changes for CCI

### DIFF
--- a/recipes/etcd-cpp-apiv3/all/conanfile.py
+++ b/recipes/etcd-cpp-apiv3/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import export_conandata_patches, get, load, copy, collect_libs, rmdir
+from conan.tools.files import export_conandata_patches, get, copy, rmdir
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 import os
 
 required_conan_version = ">=1.53.0"
@@ -11,9 +12,9 @@ class EtcdCppApiv3Conan(ConanFile):
     package_type = "library"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3"
-    license = "etcd-cpp-apiv3"
+    license = "BSD-3-Clause"
     description = ("C++ library for etcd's v3 client APIs, i.e., ETCDCTL_API=3.")
-    topics = ("etcd-cpp-apiv3", "api")
+    topics = ("etcd", "api", )
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -24,6 +25,10 @@ class EtcdCppApiv3Conan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -39,25 +44,32 @@ class EtcdCppApiv3Conan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def build_requirements(self):
+        if not self._is_legacy_one_profile:
+            self.tool_requires("protobuf/<host_version>")
+            self.tool_requires("grpc/<host_version>")
+
     def requirements(self):
         self.requires("protobuf/3.21.12")
         self.requires("openssl/[>=1.1 <4]")
         self.requires("grpc/1.54.3")
         self.requires("cpprestsdk/2.10.19", transitive_headers=True, transitive_libs=True)
 
-    def validate(self):
-        if self.dependencies["grpc"].options.shared:
-            raise ConanInvalidConfiguration("grpc must be built as a static library")
-        if self.settings.os == "Macos":
-            raise ConanInvalidConfiguration("Recipe is not MasOs ready yet")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+        if self._is_legacy_one_profile:
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
+
         tc = CMakeToolchain(self)
         tc.variables["gRPC_VERSION"] = self.dependencies["grpc"].ref.version
+        tc.variables["ETCD_CMAKE_CXX_STANDARD"] = self.settings.compiler.get_safe("cppstd", "11")
+        tc.variables["OpenSSL_DIR"] = self.dependencies["openssl"].package_folder
         tc.generate()
 
         cmake_deps = CMakeDeps(self)
@@ -76,4 +88,3 @@ class EtcdCppApiv3Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["etcd-cpp-api"]
-

--- a/recipes/etcd-cpp-apiv3/all/conanfile.py
+++ b/recipes/etcd-cpp-apiv3/all/conanfile.py
@@ -1,5 +1,4 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import export_conandata_patches, get, copy, rmdir
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/22596

This PR is my review over the PR https://github.com/conan-io/conan-center-index/pull/22596

It's working (locally) in MacOS, both static and shared. Some notes:

- Both protobuf and gRPC require theirs compilers (e.g. protoc) so we need to add tool_requires and buildenv
- The cppstd is required to work in Mac, the upstream overrides the cmake definition for it
- OpensslDIR is checked BEFORE trying to find the OpenSSL package, causing problem in Mac

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
